### PR TITLE
Fixed for plugins with spaces in file names

### DIFF
--- a/templates/install-intellij-plugins.sh.j2
+++ b/templates/install-intellij-plugins.sh.j2
@@ -54,7 +54,7 @@ install_plugin() {
         exit_code=1
     else
         sudo unzip $file_path -d $user_plugin_dir || return 2
-        (cd $user_plugin_dir && sudo unzip -Z1 $file_path | xargs chown "$idea_user:$idea_user")
+        (cd $user_plugin_dir && sudo unzip -Z1 $file_path | xargs -I '{}' chown "$idea_user:$idea_user" '{}')
     fi
 }
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -45,6 +45,7 @@
           intellij_plugins:
             - google-java-format
             - Lombook Plugin
+            - ro.redeul.google.go
         - username: test_usr2
           intellij_plugins:
         - username: test_usr3

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -7,7 +7,8 @@ testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
 
 @pytest.mark.parametrize('plugin_dir_path', [
     '/home/test_usr/.IdeaIC2016.2/config/plugins/google-java-format',
-    '/home/test_usr/.IdeaIC2016.2/config/plugins/lombok-plugin'
+    '/home/test_usr/.IdeaIC2016.2/config/plugins/lombok-plugin',
+    '/home/test_usr/.IdeaIC2016.2/config/plugins/Go'
 ])
 def test_plugins_installed(File, plugin_dir_path):
     plugin_dir = File(plugin_dir_path)


### PR DESCRIPTION
The `chown` command was failing because it was treating file names with spaces as multiple files.