### PR TITLE
Changed metadata description for consistency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: John Freeman
-  description: Role for downloading and installing IntelliJ IDEA Plugins.
+  description: Role for installing IntelliJ IDEA Plugins.
   company: GantSign Ltd.
   license: MIT
   min_ansible_version: 2.0


### PR DESCRIPTION
Changed the role metadata to make the description consistent with other GantSign roles.