### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -25,7 +25,7 @@
   become: yes
   template:
     src: install-intellij-plugins.sh.j2
-    dest: "{{ intellij_plugins_install_script }}"
+    dest: '{{ intellij_plugins_install_script }}'
     owner: root
     group: root
     mode: 'u=rwx,go='
@@ -44,7 +44,7 @@
 
 - name: install plugins
   become: yes
-  command: "{{ intellij_plugins_install_script }}"
+  command: '{{ intellij_plugins_install_script }}'
   register: plugins_result
   changed_when: 'plugins_result.rc == 0'
   failed_when: 'plugins_result.rc >= 2'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 intellij_plugins_tmp_dir: "{{ ansible_env.HOME + '/.ansible/tmp' }}"
 
 # Location of install script for plugins
-intellij_plugins_install_script: "{{ intellij_plugins_tmp_dir }}/install-intellij-plugins.sh"
+intellij_plugins_install_script: '{{ intellij_plugins_tmp_dir }}/install-intellij-plugins.sh'
 
 # Location of sudo tty workaround
 intellij_plugins_sudo_tty_workaround: /etc/sudoers.d/10-intellij-plugin-installer-sudo-tty-workaround


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.