### PR TITLE
Fixed file names of downloaded plugins

### DIFF
--- a/templates/install-intellij-plugins.sh.j2
+++ b/templates/install-intellij-plugins.sh.j2
@@ -52,7 +52,7 @@ download_plugin() {
     if [[ "$plugin_url" == *.jar ]]; then
         file_name="${plugin_url##*/}"
     else
-        if $(printf "$plugin_url" | grep --color=never --extended-regexp '^.*/([0-9]+)/([0-9]+)/([^/]+)$'); then
+        if [ $(printf "$plugin_url" | grep --color=never --extended-regexp '^.*/([0-9]+)/([0-9]+)/([^/]+)$') ]; then
             file_name=$(printf "$plugin_url" | sed --regexp-extended 's:^.*/([0-9]+)/([0-9]+)/([^/]+)$:\1-\2-\3:') || return 2
         else
             url_hash=$(printf "$plugin_url" | sha256sum | awk '{print $1}') || return 2


### PR DESCRIPTION
The test for the file name patten wasn't implemented correctly.