### PR TITLE
Migrated from docker-engine to docker-ce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -o Dpkg::Options::='--force-confold' --force-yes -y docker-engine
+  - sudo apt-get install -o Dpkg::Options::='--force-confold' --force-yes -y docker-ce
 
 install:
   # Install Ansible


### PR DESCRIPTION
The `docker-engine` package is no longer available.