### PR TITLE
Increased minimum Ansible version to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ python: '2.7'
 matrix:
   include:
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=centos
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=default
     - env:
         - ANSIBLE_VERSION=2.6.3

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ considered experimental at this time.
 Requirements
 ------------
 
-* Ansible >= 2.3
+* Ansible >= 2.4
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing IntelliJ IDEA Plugins.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
In preparation for resolving deprecated `include` warnings.