### PR TITLE
Resolved deprecation warning for include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: install-plugins.yml
+- include_tasks: install-plugins.yml
   when: "users is defined and users not in ([], None, '', omit)"


### PR DESCRIPTION
Since Ansible 2.4 `include` has been deprecated.

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
```