### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -11,13 +11,13 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     'google-java-format',
     'lombok-plugin'
 ])
-def test_plugins_installed(Command, File, plugin_dir_name):
+def test_plugins_installed(host, plugin_dir_name):
     plugins_dir_pattern = (
         '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config/plugins$')
-    plugins_dir = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr',
-                                       plugins_dir_pattern)
-    plugin_dir = File(plugins_dir + '/' + plugin_dir_name)
+    plugins_dir = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr',
+                                    plugins_dir_pattern)
+    plugin_dir = host.file(plugins_dir + '/' + plugin_dir_name)
 
     assert plugin_dir.exists
     assert plugin_dir.is_directory
@@ -26,20 +26,20 @@ def test_plugins_installed(Command, File, plugin_dir_name):
     assert oct(plugin_dir.mode) == '0755'
 
 
-def test_jar_plugin_installed(Command, File):
+def test_jar_plugin_installed(host):
     config_dir_pattern = '\\.(IdeaIC|IntelliJIdea)[0-9]+\\.[0-9]/config$'
-    config_home = Command.check_output('find %s | grep --color=never -E %s',
-                                       '/home/test_usr',
-                                       config_dir_pattern)
+    config_home = host.check_output('find %s | grep --color=never -E %s',
+                                    '/home/test_usr',
+                                    config_dir_pattern)
 
     plugins_dir = config_home + '/plugins/'
 
     sa_plugin_pattern = 'intellij-plugin-save-actions-v?[0-9\\.]+.jar'
-    plugin_path = Command.check_output('find %s | grep --color=never -E %s',
-                                       plugins_dir,
-                                       sa_plugin_pattern)
+    plugin_path = host.check_output('find %s | grep --color=never -E %s',
+                                    plugins_dir,
+                                    sa_plugin_pattern)
 
-    plugin_file = File(plugin_path)
+    plugin_file = host.file(plugin_path)
 
     assert plugin_file.exists
     assert plugin_file.is_file


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.