### PR TITLE
Removed unnecessary JDK install for tests

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -15,34 +15,8 @@
         - test_usr2
         - test_usr3
 
-    - name: install jdk 8 (apt)
-      become: yes
-      apt:
-        name: openjdk-8-jdk
-        state: present
-      when: ansible_pkg_mgr == 'apt'
-
-    - name: install jdk 8 (yum)
-      become: yes
-      yum:
-        name: java-1.8.0-openjdk-devel
-        state: present
-      when: ansible_pkg_mgr == 'yum'
-
-    - name: set facts for openjdk location (apt)
-      set_fact:
-        jdk8_home: '/usr/lib/jvm/java-1.8.0-openjdk-amd64'
-      when: ansible_pkg_mgr == 'apt'
-
-    - name: set facts for openjdk location (yum)
-      set_fact:
-        jdk8_home: '/usr/lib/jvm/java-1.8.0-openjdk'
-      when: ansible_pkg_mgr == 'yum'
-
   roles:
     - role: gantsign.intellij
-      intellij_default_jdk_home: '{{ jdk8_home }}'
-      intellij_default_maven_home: '/test/maven/home'
 
     - role: ansible-role-intellij-plugins
       users:


### PR DESCRIPTION
The IntelliJ role no longer requires a separate JDK.