### PR TITLE
Fixed role for use without gantsign.intellij role

### DIFF
--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -4,14 +4,14 @@
   package:
     name: python-lxml
     state: present
-  when: "intellij_python_major_version == '2'"
+  when: "intellij_plugins_python_major_version == '2'"
 
 - name: install Python XML support (Python 3)
   become: yes
   package:
     name: "python3-lxml"
     state: present
-  when: "intellij_python_major_version == '3'"
+  when: "intellij_plugins_python_major_version == '3'"
 
 - name: install plugins
   become: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
-# vars file for ansible-role-intellij-plugins
+# The Major version on Python being used to install this role
+intellij_plugins_python_major_version: "{{ ansible_python_version | regex_replace('^([0-9]+).*', '\\1') }}"


### PR DESCRIPTION
Was dependent on `intellij_python_major_version` variable.