### PR TITLE
Increased minimum Ansible version to 2.8

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+skip_list:
+- '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
 jobs:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=centos
       python: '2.7'
     - env:
-        - MOLECULEW_ANSIBLE=2.7.15
+        - MOLECULEW_ANSIBLE=2.8.16
         - MOLECULE_SCENARIO=default
       python: '2.7'
     - env:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ considered experimental at this time.
 Requirements
 ------------
 
-* Ansible >= 2.7
+* Ansible >= 2.8
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing IntelliJ IDEA Plugins.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: 2.8
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.8.