### PR TITLE
Migrated to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role: IntelliJ Plugins
 ==============================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-intellij-plugins.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-intellij-plugins)
+[![Build Status](https://travis-ci.com/gantsign/ansible-role-intellij-plugins.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-intellij-plugins)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.intellij--plugins-blue.svg)](https://galaxy.ansible.com/gantsign/intellij-plugins)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-intellij-plugins/master/LICENSE)
 


### PR DESCRIPTION
`travis-ci.org` will be discontinued in December.