### PR TITLE
Fixed install for plugins with missing dirs in zip

### DIFF
--- a/library/intellij_plugins_install.py
+++ b/library/intellij_plugins_install.py
@@ -82,7 +82,10 @@ def extract_zip(module, output_dir, zipfile_path, owner):
 
     for file_entry in files:
         absolute_file = os.path.join(output_dir, file_entry)
-        os.chown(absolute_file, uid, gid)
+        while not os.path.samefile(absolute_file, output_dir):
+            os.chown(absolute_file, uid, gid)
+            absolute_file = os.path.normpath(
+                os.path.join(absolute_file, os.pardir))
 
 
 def fetch_url(module, url, method=None, timeout=10, follow_redirects=True):

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -28,6 +28,6 @@
         - username: test_usr
           intellij_plugins:
             - google-java-format
-            - Lombook Plugin
+            - MavenRunHelper
             - com.dubreuia
         - username: test_usr2

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.parametrize('plugin_dir_name', [
     'google-java-format',
-    'lombok-plugin'
+    'MavenRunHelper'
 ])
 def test_plugins_installed(host, plugin_dir_name):
     plugins_dir_pattern = (


### PR DESCRIPTION
The install was failing to set the ownership unless the directory is an entry in the zip file.