### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
             * Focal (20.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,6 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
   galaxy_tags:

--- a/molecule/ubuntu-ultimate/molecule.yml
+++ b/molecule/ubuntu-ultimate/molecule.yml
@@ -15,7 +15,7 @@ platforms:
   - name: ansible-role-intellij-plugins-ultimate-ubuntu
     groups:
       - ultimate
-    image: ubuntu:16.04
+    image: ubuntu:18.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.