### PR TITLE
Fixed Rocky Linux tests

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,6 +9,12 @@
       changed_when: no
       when: "ansible_pkg_mgr == 'apt'"
 
+    - name: install find (dnf)
+      dnf:
+        name: findutils
+        state: present
+      when: "ansible_pkg_mgr == 'dnf'"
+
     - name: create test users
       become: yes
       user:


### PR DESCRIPTION
It seems `find` is not longer installed by default.